### PR TITLE
🔧 [CHORE] 도커 이미지 openJDK 변경 #54

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM eclipse-temurin:17-jd
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-jar","/app.jar","--spring.profiles.active=dev"]


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호

#54 
<br>

## 📝작업 내용
- [x] 도커 이미지 openJDK17 -> eclipse-temurin:17-jd로 변경


<br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
